### PR TITLE
use expand('%:t') instead of split()

### DIFF
--- a/plugin/simplenote.vim
+++ b/plugin/simplenote.vim
@@ -365,9 +365,8 @@ class SimplenoteVimInterface(object):
 
     def get_current_note(self):
         """ returns the key of the currently edited note """
-        filename = vim.current.buffer.name
-        key = filename.split("/")
-        return key[-1]
+        key = vim.eval("expand('%:t')")
+        return key
 
     def set_current_note(self, key):
         """ sets the key of the currently edited note """


### PR DESCRIPTION
fix: not work if `exists('+shellslash') && &shellslash`
