### PR TITLE
Make Simplenote.vim try to use simplejson as per Simplenote.py

### DIFF
--- a/plugin/simplenote.vim
+++ b/plugin/simplenote.vim
@@ -102,7 +102,10 @@ python << ENDPYTHON
 import urllib
 import urllib2
 import base64
-import json
+try: 
+    import simplejson as json
+except ImportError: 
+    import json
 
 AUTH_URL = 'https://simple-note.appspot.com/api/login'
 DATA_URL = 'https://simple-note.appspot.com/api2/data'


### PR DESCRIPTION
Is there any reason why Simplenote.py tries to use simplejson yet Simplenote.vim doesn't? 

I had to pull this across from Simplenote.py to get Simplenote.vim to work on my old version of OSX. Meant to mention this ages ago, but forgot.
