### PR TITLE
Add modifydate to update_note() function

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -224,8 +224,12 @@ class Simplenote(object):
         if note.has_key("tags"):
             note["tags"] = [unicode(t, 'utf-8') for t in note["tags"]]
 
+
         # determine whether to create a new note or updated an existing one
         if note.has_key("key"):
+            # set modification timestamp in milli-seconds since epoch
+            note["modifydate"] = int(round(time.time() * 1000))
+
             url = '%s/%s?auth=%s&email=%s' % (DATA_URL, note["key"],
                                               self.get_token(), self.username)
         else:


### PR DESCRIPTION
Changed notes don't seem to get a modified timestamp by the server by
default. This adds the 'modifydate' key to the note object when updating
a note, with the current time in milli-seconds since epoch as value.

If this is not set, modified notes never change that modification date when
changed within vim/simplenote.vim (as they should IMHO).
