### PR TITLE
:Simplenote -l X doesn't work well when there are deleted notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,22 @@ set `g:SimplenoteFiletype` to the preferred vim filetype.
 
 ## Usage
 The plugin provides several commands to interact with your Simplenote account.
-In order to retrieve a list of your notes execute
+In order to retrieve a list of your notes execute one of the
+following:
 
-    :Simplenote -l X
+    :Simplenote -l
+    :Simplenote -l YYYY-MM-DD
     :Simplenote -l todo,shopping
 
-Where X is the number of notes to retrieve; omit X to retrieve all.  This opens
-a new scratch buffer with a line-wise listing of your notes. With `let
+The first option returns all notes, the second returns only those notes modified
+since YYYY-MM-DD, the third option shows passing a comma separated list of tags;
+this will only list notes which have at least one of those tags.  This opens a
+new scratch buffer with a line-wise listing of your notes. With `let
 g:SimplenoteListHeight=X` set, the scratch buffer will come up X lines tall.
 Alternatively when `let g:SimplenoteVertical=1` is set, it is opened as a
-vertical rather than horizontal split window. You can also pass a comma
-separated list of tags. This will only list notes which have at least one of
-those tags. You can then navigate through the with the arrow keys and enter a
-note on hitting `Return`. Now that you see the content of the note, you can
-interact with this specific note:
+vertical rather than horizontal split window.  You can then navigate through the
+with the arrow keys and enter a note on hitting `Return`. Now that you see the
+content of the note, you can interact with this specific note:
 
     :Simplenote -u
 


### PR DESCRIPTION
You can assign this one to me.

Previously doing something like `:Simplenote -l 10` worked really well for me and returned the 10 most recent notes. However, now by limiting the number of notes fetched to 10 I will end up with just one note being listed in Vim (because the other 9 fetched will have the "deleted" flag set). I don't know if it is because something has changed in the API or whether it's because I've more deleted notes.

I thought the API returned the note index starting with the most recent note? I'm sure that is how it worked when I added in the "limit list" bit. However, now it seems to return the oldest note first and since a lot of my older notes are more likely to have the "deleted" flag set that's why I end up with one note, etc being displayed. The only API doc I've got access to is v2.1.5. Do you know if there have been any changes since this?

The [limit list functionality in Simplenote.py](https://github.com/mrtazz/simplenote.py/commit/4721cb9cc275294465de9e13a4bf92527042b75c) works, but the problem with how I implemented it in Simplenote.vim is that I did not appreciate or take into account that Simplenote.vim [filters the returned list for display](https://github.com/mrtazz/simplenote.vim/blob/master/autoload/simplenote.vim#L588-L589).

So... there are two problems
1. I need to rethink how it works. I guess I just for each fetch of notes I just need to count how many aren't deleted and continue fetching until enough undeleted notes are retrieved. But...
2. This doesn't help with the fact that the api now seems to be returning results in reverse order. I don't really care for my oldest 10 notes :-(. 

Perhaps I'd be better scrapping the "limit list" idea and using the "modified since" option in the API for a way of limiting the notes returned?
