### PR TITLE
Fix double encoding

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -462,7 +462,7 @@ class SimplenoteVimInterface(object):
         width = int(width)
 
         # get note tags
-        tags = "[%s]" % ",".join([t.encode('utf-8') for t in note["tags"]])
+        tags = "[%s]" % ",".join(note["tags"])
 
         # format date
         mt = time.localtime(float(note["modifydate"]))


### PR DESCRIPTION
This note["tags"] has already been encoded utf-8 in Simplenote#get_note.

```
Error detected while processing function simplenote#SimpleNote:
line   37:
Traceback (most recent call last):
  File "<string>", line 10, in <module>
  File "<string>", line 499, in list_note_index_in_scratch_buffer
  File "<string>", line 346, in format_title
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 4: ordinal not in range(128)
```
