### PR TITLE
force autocommand processing for the BufReadPost group when the buffer is set by python

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -359,6 +359,7 @@ class SimplenoteVimInterface(object):
             if markdown:
                 vim.command("setlocal filetype=markdown")
             self.set_current_note(note["key"])
+            vim.command("doautocmd BufReadPost")
             print "New note created."
         else:
             print "Update failed.: %s" % note["key"]


### PR DESCRIPTION
I'm not totally sure this is the right solution to the problem, but my change works as expected.

For some reason when setting vim.current.buffer in the python code, any modelines in the note are not processed by vim. Forcing a call to doautocmd triggers modeline processing. I picked the BufReadPost group as that made the most sense.

I like to use modelines in my notes to set the FileType. Specifically txt files formatted as votl/vimorganizer files.

I couldn't see anything in the global/local settings of the note buffer that would prevent the modeline from being processed. I know for a fact modeline=1 and modelines=5 and my modeline is the last line of the txt note.
