### PR TITLE
initialize the variable

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -225,6 +225,8 @@ class SimplenoteVimInterface(object):
 
         Returns the visible length of the title
         """
+        length = 0
+
         if vim.eval("has('conceal')") == "1":
             # exclude the "|F|...|" syntax tag
             title = re.sub(r"(.*?)\|F\|(.*?)\|(.*?)", r"\1\2\3", title)


### PR DESCRIPTION
I get an error

:Simplenote -l

Traceback (most recent call last):
  File "<string>", line 12, in <module>
  File "<string>", line 440, in list_note_index_in_scratch_buffer
  File "<string>", line 212, in format_title
  File "<string>", line 96, in format_title_len_no_conceal
UnboundLocalError: local variable 'length' referenced before assignment

Probably it is an error to happen because length of simplenote.vim #242 is not initialized.
It was recovered when I initialized a variable with 0.

I beg your kindness.
