### PR TITLE
prompt to input user/pass when missing

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -66,13 +66,13 @@ else
   let s:sortorder = "pinned, modifydate"
 endif
 
-if (s:user == "") || (s:password == "")
-  let errmsg = "Simplenote credentials missing. Set g:SimplenoteUsername and "
-  let errmsg = errmsg . "g:SimplenotePassword. If you don't have an account you can "
-  let errmsg = errmsg . "create one at https://simple-note.appspot.com/create/."
-  echoerr errmsg
-  finish
-endif
+" if (s:user == "") || (s:password == "")
+  " let errmsg = "Simplenote credentials missing. Set g:SimplenoteUsername and "
+  " let errmsg = errmsg . "g:SimplenotePassword. If you don't have an account you can "
+  " let errmsg = errmsg . "create one at https://simple-note.appspot.com/create/."
+  " echoerr errmsg
+  " finish
+" endif
 
 "
 " Helper functions
@@ -157,8 +157,6 @@ from threading import Thread
 from Queue import Queue
 
 DEFAULT_SCRATCH_NAME = vim.eval("g:simplenote_scratch_buffer")
-SN_USER = vim.eval("s:user")
-SN_PASSWORD = vim.eval("s:password")
 
 class SimplenoteVimInterface(object):
     """ Interface class to provide functions for interacting with VIM """
@@ -702,9 +700,6 @@ class NoteFetcher(Thread):
 
         self.queue.task_done()
 
-interface = SimplenoteVimInterface(SN_USER, SN_PASSWORD)
-
-
 ENDPYTHON
 
 "
@@ -728,49 +723,61 @@ endfunction
 
 function! simplenote#SimpleNote(param, ...)
 python << EOF
-param = vim.eval("a:param")
-optionsexist = True if (float(vim.eval("a:0"))>=1) else False
-if param == "-l":
-    if optionsexist:
+def simplenote():
+    if vim.eval('s:user') == '' or vim.eval('s:password') == '':
         try:
-            # check for valid date string
-            datetime.datetime.strptime(vim.eval("a:1"), "%Y-%m-%d")
-            interface.list_note_index_in_scratch_buffer(since=vim.eval("a:1"))
-        except ValueError:
-            interface.list_note_index_in_scratch_buffer(tags=vim.eval("a:1").split(","))
+            vim.command("let s:user=input('username:', '')")
+            vim.command("let s:password=inputsecret('password:', '')")
+        except KeyboardInterrupt:
+            return
+
+    SN_USER = vim.eval("s:user")
+    SN_PASSWORD = vim.eval("s:password")
+    interface = SimplenoteVimInterface(SN_USER, SN_PASSWORD)
+
+    param = vim.eval("a:param")
+    optionsexist = True if (float(vim.eval("a:0"))>=1) else False
+    if param == "-l":
+        if optionsexist:
+            try:
+                # check for valid date string
+                datetime.datetime.strptime(vim.eval("a:1"), "%Y-%m-%d")
+                interface.list_note_index_in_scratch_buffer(since=vim.eval("a:1"))
+            except ValueError:
+                interface.list_note_index_in_scratch_buffer(tags=vim.eval("a:1").split(","))
+        else:
+            interface.list_note_index_in_scratch_buffer()
+
+    elif param == "-d":
+        interface.trash_current_note()
+
+    elif param == "-u":
+        interface.update_note_from_current_buffer()
+
+    elif param == "-n":
+        interface.create_new_note_from_current_buffer()
+
+    elif param == "-D":
+        interface.delete_current_note()
+
+    elif param == "-t":
+        interface.set_tags_for_current_note()
+
+    elif param == "-p":
+        interface.pin_current_note()
+
+    elif param == "-P":
+        interface.unpin_current_note()
+
+    elif param == "-o":
+        if optionsexist:
+            interface.display_note_in_scratch_buffer(vim.eval("a:1"))
+        else:
+            print "No notekey given."
+
     else:
-        interface.list_note_index_in_scratch_buffer()
-
-elif param == "-d":
-    interface.trash_current_note()
-
-elif param == "-u":
-    interface.update_note_from_current_buffer()
-
-elif param == "-n":
-    interface.create_new_note_from_current_buffer()
-
-elif param == "-D":
-    interface.delete_current_note()
-
-elif param == "-t":
-    interface.set_tags_for_current_note()
-
-elif param == "-p":
-    interface.pin_current_note()
-
-elif param == "-P":
-    interface.unpin_current_note()
-
-elif param == "-o":
-    if optionsexist:
-        interface.display_note_in_scratch_buffer(vim.eval("a:1"))
-    else:
-        print "No notekey given."
-
-else:
-    print "Unknown argument"
-
+        print "Unknown argument"
+simplenote()
 EOF
 endfunction
 


### PR DESCRIPTION
if no username or password is pre-configured, will prompt user to input. And the authentication moved in `simplenote#SimpleNote()`, thus the plugin won't explode if you interrupt your first login and want to login again