### PR TITLE
Update instructions for installing with Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ But it's easier to use a plugin manager:
 
 ### [Vundle](https://github.com/gmarik/vundle)
 
-    Add Bundle 'mrtazz/simplenote.vim' to .vimrc
-    Run :BundleInstall
+    Add Plugin 'mrtazz/simplenote.vim' to .vimrc
+    Run :PluginInstall
 
 ### [NeoBundle](https://github.com/Shougo/neobundle.vim)
 


### PR DESCRIPTION
The `bundle` commands have been [deprecated for a while](https://github.com/VundleVim/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396) in favor of `plugin`.