### PR TITLE
Use prefixed commands rather than flags #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ to create shortcuts to notes you use often. Example:
 
 Now you can jump to your todo note directly with `:Todo` in vim.
 
+Also, if g:SimplenotePrefix is set, it is used to define aliases for these
+commands. Example:
+
+    :let g:SimplenotePrefix = "Sn"
+
+    :Snlist          " alias for :Simplenote -l
+    :Snupdate        " alias for :Simplenote -u
+    :Sntrash         " alias for :Simplenote -d
+    :Snnew           " alias for :Simplenote -n
+    :Sndelete        " alias for :Simplenote -D
+    :Sntag           " alias for :Simplenote -t
+    :Snpin           " alias for :Simplenote -p
+    :Snunpin         " alias for :Simplenote -P
+    :Snkey           " alias for :Simplenote -o
+
 ## Note sorting
 simplenote.vim supports simple note ordering. Per default the sort order is
 pinned notes first followed by modified date from newest to oldest. The order

--- a/doc/simplenote.txt
+++ b/doc/simplenote.txt
@@ -98,7 +98,7 @@ If set, the split windows will be opened vertical instead of horizontal. >
 
                                                   *'simplenote_single_window'*
 Default: 0
-If set, simplenote.vim will try to emulate the behaviout of the Simplenote
+If set, simplenote.vim will try to emulate the behaviour of the Simplenote
 website and display the list index and only one note open at a time. >
     g:SimplenoteSingleWindow=1
 <

--- a/doc/simplenote.txt
+++ b/doc/simplenote.txt
@@ -149,6 +149,27 @@ If you are behind a proxy set these to the correct values. >
     let $HTTPS_PROXY = 'http://<user>:<password>@<proxyurl>:<proxyport>'
 <
 
+                                                         *'simplenote_prefix'*
+Default: "Simplenote"
+If set, aliases for main command are defined. Assign empty string to disable
+aliases. For example, if following line is present in your .vimrc: >
+    g:SimplenotePrefix="Sn"
+
+, then following aliases are available: >
+
+    :SnList          " alias for :Simplenote -l
+    :SnUpdate        " alias for :Simplenote -u
+    :SnVersionInfo   " alias for :Simplenote -V
+    :SnVersion       " alias for :Simplenote -v
+    :SnTrash         " alias for :Simplenote -d
+    :SnDelete        " alias for :Simplenote -D
+    :SnNew           " alias for :Simplenote -n
+    :SnTags          " alias for :Simplenote -t
+    :SnPin           " alias for :Simplenote -p
+    :SnUnpin         " alias for :Simplenote -P
+    :SnOpen          " alias for :Simplenote -o
+<
+
 ==============================================================================
 4. Colors                                                  *simplenote-colors*
 

--- a/plugin/simplenote.vim
+++ b/plugin/simplenote.vim
@@ -24,3 +24,15 @@
 " set the simplenote command
 command! -nargs=+ Simplenote :call simplenote#SimpleNote(<f-args>)
 
+if exists('g:simplenote_prefix')
+  execute "command! -nargs=? " . g:simplenote_prefix . 'list'      . "  :call simplenote#SimpleNote('-l', <f-args>)"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'update'    . "  :call simplenote#SimpleNote('-u')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'delete'    . "  :call simplenote#SimpleNote('-d')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'new'       . "  :call simplenote#SimpleNote('-n')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'deletebuf' . "  :call simplenote#SimpleNote('-D')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'tag'       . "  :call simplenote#SimpleNote('-t')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'pin'       . "  :call simplenote#SimpleNote('-p')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'unpin'     . "  :call simplenote#SimpleNote('-P')"
+  execute "command! -nargs=1 " . g:simplenote_prefix . 'key'       . "  :call simplenote#SimpleNote('-o')"
+endif
+

--- a/plugin/simplenote.vim
+++ b/plugin/simplenote.vim
@@ -21,18 +21,24 @@
 " see plugin/simplenote.vim
 "
 
+if !exists('g:SimplenotePrefix')
+  g:SimplenotePrefix = "Simplenote"
+endif
+
 " set the simplenote command
 command! -nargs=+ Simplenote :call simplenote#SimpleNote(<f-args>)
 
-if exists('g:simplenote_prefix')
-  execute "command! -nargs=? " . g:simplenote_prefix . 'list'   . "  :call simplenote#SimpleNote('-l', <f-args>)"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'update' . "  :call simplenote#SimpleNote('-u')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'trash'  . "  :call simplenote#SimpleNote('-d')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'new'    . "  :call simplenote#SimpleNote('-n')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'delete' . "  :call simplenote#SimpleNote('-D')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'tag'    . "  :call simplenote#SimpleNote('-t')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'pin'    . "  :call simplenote#SimpleNote('-p')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'unpin'  . "  :call simplenote#SimpleNote('-P')"
-  execute "command! -nargs=1 " . g:simplenote_prefix . 'key'    . "  :call simplenote#SimpleNote('-o')"
+if g:SimplenotePrefix != ''
+  execute "command! -nargs=? " . g:SimplenotePrefix . 'List'        . "  :call simplenote#SimpleNote('-l', <f-args>)"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Update'      . "  :call simplenote#SimpleNote('-u')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'VersionInfo' . "  :call simplenote#SimpleNote('-V')"
+  execute "command! -nargs=? " . g:SimplenotePrefix . 'Version'     . "  :call simplenote#SimpleNote('-v', <f-args>)"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Trash'       . "  :call simplenote#SimpleNote('-d')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Delete'      . "  :call simplenote#SimpleNote('-D')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'New'         . "  :call simplenote#SimpleNote('-n')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Tags'        . "  :call simplenote#SimpleNote('-t')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Pin'         . "  :call simplenote#SimpleNote('-p')"
+  execute "command! -nargs=0 " . g:SimplenotePrefix . 'Unpin'       . "  :call simplenote#SimpleNote('-P')"
+  execute "command! -nargs=1 " . g:SimplenotePrefix . 'Open'        . "  :call simplenote#SimpleNote('-o')"
 endif
 

--- a/plugin/simplenote.vim
+++ b/plugin/simplenote.vim
@@ -25,14 +25,14 @@
 command! -nargs=+ Simplenote :call simplenote#SimpleNote(<f-args>)
 
 if exists('g:simplenote_prefix')
-  execute "command! -nargs=? " . g:simplenote_prefix . 'list'      . "  :call simplenote#SimpleNote('-l', <f-args>)"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'update'    . "  :call simplenote#SimpleNote('-u')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'delete'    . "  :call simplenote#SimpleNote('-d')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'new'       . "  :call simplenote#SimpleNote('-n')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'deletebuf' . "  :call simplenote#SimpleNote('-D')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'tag'       . "  :call simplenote#SimpleNote('-t')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'pin'       . "  :call simplenote#SimpleNote('-p')"
-  execute "command! -nargs=0 " . g:simplenote_prefix . 'unpin'     . "  :call simplenote#SimpleNote('-P')"
-  execute "command! -nargs=1 " . g:simplenote_prefix . 'key'       . "  :call simplenote#SimpleNote('-o')"
+  execute "command! -nargs=? " . g:simplenote_prefix . 'list'   . "  :call simplenote#SimpleNote('-l', <f-args>)"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'update' . "  :call simplenote#SimpleNote('-u')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'trash'  . "  :call simplenote#SimpleNote('-d')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'new'    . "  :call simplenote#SimpleNote('-n')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'delete' . "  :call simplenote#SimpleNote('-D')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'tag'    . "  :call simplenote#SimpleNote('-t')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'pin'    . "  :call simplenote#SimpleNote('-p')"
+  execute "command! -nargs=0 " . g:simplenote_prefix . 'unpin'  . "  :call simplenote#SimpleNote('-P')"
+  execute "command! -nargs=1 " . g:simplenote_prefix . 'key'    . "  :call simplenote#SimpleNote('-o')"
 endif
 


### PR DESCRIPTION
- added prefixed commands with prefix g:simplenote_prefix
- fixed misprint in doc/simplenote.txt