### PR TITLE
Add configurable vertical list width

### DIFF
--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -313,6 +313,12 @@ class SimplenoteVimInterface(object):
                 vim.command("vertical resize " + vim.eval("s:listsize"))
                 vim.command("wincmd p")
 
+            # if vertical is not on, we can try to resize the list window to the
+            # desired size
+            if vim.eval('s:vbuff == 0 && s:listsize > 0') == "1":
+                vim.command("wincmd p")
+                vim.command("resize " + vim.eval("s:listsize"))
+                vim.command("wincmd p")
 
     def update_note_from_current_buffer(self):
         """ updates the currently displayed note to the web service or creates new """

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -306,13 +306,15 @@ class SimplenoteVimInterface(object):
                 if ("markdown" in note["systemtags"]):
                     vim.command("setlocal filetype=markdown")
 
-            if (vim.eval("(s:vbuff == 1) && (s:listwidth > 0)")):
+            # if vertical is on, we can try to resize the list window to the
+            # desired size
+            if vim.eval('s:vbuff == 1 && s:listsize > 0') == "1":
                 vim.command("wincmd p")
-                vim.command("vertical resize " + vim.eval("s:listwidth"))
+                vim.command("vertical resize " + vim.eval("s:listsize"))
 
 
     def update_note_from_current_buffer(self):
-        """ updates the currently displayed note to the web service or creates new"""
+        """ updates the currently displayed note to the web service or creates new """
         note_id = self.get_current_note()
         content = "\n".join(str(line) for line in vim.current.buffer[:])
         # Need to get note details first to assess remote markdown status

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -305,10 +305,11 @@ class SimplenoteVimInterface(object):
             if "systemtags" in note:
                 if ("markdown" in note["systemtags"]):
                     vim.command("setlocal filetype=markdown")
-            # TODO: only if we are using vertical spli
-            # TODO: make vertical note list width configurable
-            vim.command("wincmd p")
-            vim.command("vertical resize 35")
+
+            if (vim.eval("(s:vbuff == 1) && (s:listwidth > 0)")):
+                vim.command("wincmd p")
+                vim.command("vertical resize " + vim.eval("s:listwidth"))
+
 
     def update_note_from_current_buffer(self):
         """ updates the currently displayed note to the web service or creates new"""

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -311,6 +311,7 @@ class SimplenoteVimInterface(object):
             if vim.eval('s:vbuff == 1 && s:listsize > 0') == "1":
                 vim.command("wincmd p")
                 vim.command("vertical resize " + vim.eval("s:listsize"))
+                vim.command("wincmd p")
 
 
     def update_note_from_current_buffer(self):

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -305,6 +305,8 @@ class SimplenoteVimInterface(object):
             if "systemtags" in note:
                 if ("markdown" in note["systemtags"]):
                     vim.command("setlocal filetype=markdown")
+            # TODO: only if we are using vertical spli
+            # TODO: make vertical note list width configurable
             vim.command("wincmd p")
             vim.command("vertical resize 35")
 

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -305,6 +305,8 @@ class SimplenoteVimInterface(object):
             if "systemtags" in note:
                 if ("markdown" in note["systemtags"]):
                     vim.command("setlocal filetype=markdown")
+            vim.command("wincmd p")
+            vim.command("vertical resize 35")
 
     def update_note_from_current_buffer(self):
         """ updates the currently displayed note to the web service or creates new"""
@@ -331,7 +333,7 @@ class SimplenoteVimInterface(object):
             if status == 0:
                 print("Update successful.")
                 self.note_version[note_id] = note["version"]
-                # Merging content. 
+                # Merging content.
                 if 'content' in note:
                     buffer = vim.current.buffer
                     buffer[:] = list(map(lambda x: str(x), note["content"].split("\n")))

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -67,14 +67,23 @@ else
   let s:vbuff = 0
 endif
 
-" line height
+" list height
 if exists("g:SimplenoteListHeight")
   let s:lineheight = g:SimplenoteListHeight
 else
   let s:lineheight = 0
 endif
 
-" line height
+
+" list width (for vertical buffer only)
+if exists("g:SimplenoteListWidth")
+  let s:listwidth = g:SimplenoteListWidth
+else
+  let s:listwidth = 0 
+endif
+
+
+" sort order
 if exists("g:SimplenoteSortOrder")
   let s:sortorder = g:SimplenoteSortOrder
 else

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -173,7 +173,7 @@ function! s:ScratchBuffer()
     setlocal cursorline
 
     if (s:vbuff == 0) && (s:listsize > 0)
-        exe "resize " . s:listsize
+    "    exe "resize " . s:listsize
     endif
 endfunction
 

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -67,19 +67,12 @@ else
   let s:vbuff = 0
 endif
 
-" list height
-if exists("g:SimplenoteListHeight")
-  let s:lineheight = g:SimplenoteListHeight
-else
-  let s:lineheight = 0
-endif
 
-
-" list width (for vertical buffer only)
-if exists("g:SimplenoteListWidth")
-  let s:listwidth = g:SimplenoteListWidth
+" list size, used for both vertical and horizontal buffer
+if exists("g:SimplenoteListSize")
+  let s:listsize = g:SimplenoteListSize
 else
-  let s:listwidth = 0 
+  let s:listsize = 0 
 endif
 
 
@@ -179,8 +172,8 @@ function! s:ScratchBuffer()
     setlocal noswapfile
     setlocal cursorline
 
-    if (s:vbuff == 0) && (s:lineheight > 0)
-        exe "resize " . s:lineheight
+    if (s:vbuff == 0) && (s:listsize > 0)
+        exe "resize " . s:listsize
     endif
 endfunction
 

--- a/doc/simplenote.txt
+++ b/doc/simplenote.txt
@@ -84,11 +84,6 @@ Set the Password for the Simplenote account to use. >
     g:SimplenotePassword="verysecret"
 <
 
-                                                    *'simplenote_list_height'*
-Default: 50% of the current buffer
-If set, the split windows will be opened with the given height in lines. >
-    g:SimplenoteListHeight=30
-<
 
                                                        *'simplenote_vertical'*
 Default: 0
@@ -96,10 +91,11 @@ If set, the split windows will be opened vertical instead of horizontal. >
     g:SimplenoteVertical=1
 <
 
-                                                    *'simplenote_list_width'*
+                                                      *'simplenote_list_size'*
 Default: 50% of the current buffer
-If set, the vertically split windows will be opened with the given width in lines. >
-    g:SimplenoteListWidth=30
+If set, sets the width or height of the note list (Depending on 
+the setting of 'simplenote_vertical'). >
+    g:SimplenoteListSize=30
 <
 
                                                   *'simplenote_single_window'*

--- a/doc/simplenote.txt
+++ b/doc/simplenote.txt
@@ -96,6 +96,12 @@ If set, the split windows will be opened vertical instead of horizontal. >
     g:SimplenoteVertical=1
 <
 
+                                                    *'simplenote_list_width'*
+Default: 50% of the current buffer
+If set, the vertically split windows will be opened with the given width in lines. >
+    g:SimplenoteListWidth=30
+<
+
                                                   *'simplenote_single_window'*
 Default: 0
 If set, simplenote.vim will try to emulate the behaviour of the Simplenote


### PR DESCRIPTION
When using the default horizontal split, note list height is configurable. I use vertical split, so I would like note width to be configurable as well (the default 50% in my case is a waste or screen real estate).

I added a new `g:SimplenoteListWidth` parameter, which is used when opening a new note to adjust the width of the list window