### PR TITLE
support for :saveas {file} and :w {file}

### DIFF
--- a/autoload/SimplenoteUpdate.py
+++ b/autoload/SimplenoteUpdate.py
@@ -1,5 +1,5 @@
 def SimplenoteUpdate():
-    interface.update_note_from_current_buffer()
+    interface.update_note_to_web_service()
 
 try:
     set_cred()

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -344,14 +344,6 @@ class SimplenoteVimInterface(object):
         currentfile=vim.eval("expand('%:p')") # the filename of this buffer
         renaming=vim.eval("s:renaming")       # is the user changing THIS buffer's file name? (:saveas)
 
-
-        print("amatch: " + amatch)
-        print("currentfile: " + currentfile)
-        print("renaming: " + renaming)
-
-
-
-
         if os.path.basename(currentfile) != os.path.basename(amatch):
             # user is executing :w <newfile>
             self.save_buffer_to_file()

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -337,25 +337,22 @@ class SimplenoteVimInterface(object):
 
     def update_note_from_current_buffer(self):
         """ updates the currently displayed note to the web service or creates new """
-        #
+
         # what information do we have?
         amatch=vim.eval('expand("<amatch>")') # the desired path+file name (:w command parameter, for example)
         currentfile=vim.eval("expand('%:p')") # the filename of this buffer
         renaming=vim.eval("s:renaming")       # is the user changing THIS buffer's file name? (:saveas)
-        #
+
         # based on the available information, let's try to find out what the
         # user action is
         if os.path.basename(currentfile) != os.path.basename(amatch):
             userAction="writingBufferToADifferentFile" # user is executing :w <newfile>
+        elif renaming == "0":
+            userAction="updatingNote"
         else:
-            if renaming == "0":
-                userAction="updatingNote"
-            else:
-                userAction="renamingBuffer"
-
+            userAction="renamingBuffer"
 
         if userAction=="updatingNote":
-            #
             note_id = self.get_current_note()
             content = "\n".join(str(line) for line in vim.current.buffer[:])
             # Need to get note details first to assess remote markdown status
@@ -399,11 +396,10 @@ class SimplenoteVimInterface(object):
                 self.create_new_note_from_current_buffer()
             else:
                 print("Update failed.: %s" % note)
-        else:
+        elif userAction=="renamingBuffer" or userAction=="writingBufferToADifferentFile":
             # user is renaming, probably executing :saveas or :w <file>
             # vim.command("au! * <buffer> ")
-            if userAction=="renamingBuffer" or userAction=="writingBufferToADifferentFile":
-                self.save_buffer_to_file()
+            self.save_buffer_to_file()
             if userAction=="renamingBuffer":
                 # when :saveas-ing, a new buffer is created
                 # so we are going to delete it, another option could be transforming
@@ -416,8 +412,6 @@ class SimplenoteVimInterface(object):
                 vim.command("au! BufWriteCmd <buffer>")
                 vim.command("au! BufFilePre <buffer>")
                 vim.command("setlocal buftype=")
-
-
 
 
     def save_buffer_to_file(self):

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -46,6 +46,7 @@ class SimplenoteVimInterface(object):
         vim.command("setlocal buftype=acwrite")
         vim.command("setlocal nomodified")
         vim.command("au! BufWriteCmd <buffer> call s:UpdateNoteFromCurrentBuffer()")
+        vim.command("au! BufFilePre <buffer> call s:PreRenameBuffer()")
 
     def format_title_build(self, title, fmt_char, value_str, conceal_str):
         """ function to replace a format tag in the title
@@ -342,6 +343,14 @@ class SimplenoteVimInterface(object):
         amatch=vim.eval('expand("<amatch>")') # the desired path+file name (:w command parameter, for example)
         currentfile=vim.eval("expand('%:p')") # the filename of this buffer
         renaming=vim.eval("s:renaming")       # is the user changing THIS buffer's file name? (:saveas)
+
+
+        print("amatch: " + amatch)
+        print("currentfile: " + currentfile)
+        print("renaming: " + renaming)
+
+
+
 
         if os.path.basename(currentfile) != os.path.basename(amatch):
             # user is executing :w <newfile>

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -351,7 +351,7 @@ class SimplenoteVimInterface(object):
         else:
             is_this_still_a_note = 0
         #
-        if renaming == "0" and currentfile == amatch and is_this_still_a_note:
+        if renaming == "0" and os.path.basename(currentfile) == os.path.basename(amatch) and is_this_still_a_note:
             #
             note_id = self.get_current_note()
             content = "\n".join(str(line) for line in vim.current.buffer[:])
@@ -458,10 +458,13 @@ class SimplenoteVimInterface(object):
 
             # when :saveas-ing, a new buffer is created, it serves no purpose
             # so we are going to delete it
-            if currentfile == amatch and renaming == "1":
+            if os.path.basename(currentfile) == os.path.basename(amatch) and renaming == "1":
                 newBufferIndex = len(vim.buffers)
                 vim.command("bd {0}".format(newBufferIndex))
-                del self.bufnum_to_noteid[abuf]
+                del self.bufnum_to_noteid[vim.current.buffer.number]
+                vim.command("au! BufWriteCmd <buffer>")
+                vim.command("au! BufFilePre <buffer>")
+                vim.command("setlocal buftype=")
 
 
         vim.command("let s:renaming = 0")

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -231,6 +231,22 @@ EOF
 endif
 endfunction
 
+
+" function to update note from buffer content
+function! s:PostRenameBuffer()
+if has("python")
+python << EOF
+interface.post_rename_buffer()
+EOF
+elseif has("python3")
+python3 << EOF
+interface.post_rename_buffer()
+EOF
+endif
+endfunction
+
+
+
 if has("python")
     execute 'pyfile ' . s:scriptpath . "/SimplenoteCmd.py" 
 elseif has("python3")

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -232,15 +232,16 @@ endif
 endfunction
 
 
-" function to update note from buffer content
-function! s:PostRenameBuffer()
+" function to detect if user is renaming the buffer (via :saveas command,
+" probably)
+function! s:PreRenameBuffer()
 if has("python")
 python << EOF
-interface.post_rename_buffer()
+interface.pre_rename_buffer()
 EOF
 elseif has("python3")
 python3 << EOF
-interface.post_rename_buffer()
+interface.pre_rename_buffer()
 EOF
 endif
 endfunction

--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -91,6 +91,8 @@ endif
 let g:simplenote_scratch_buffer = 'Simplenote'
 " Initialise the window number that notes will be displayed in. This needs to start as 0.
 let g:simplenote_note_winnr = 0
+" Initialise the variable that lets us know if user is renaming current buffer
+let s:renaming = "0"
 
 " Function that opens or navigates to the scratch buffer.
 " TODO: This is a complicated mess and it would be nice to improve it, but I'm really not sure how.

--- a/tests/simplenote.vader
+++ b/tests/simplenote.vader
@@ -101,16 +101,16 @@ Given:
 
 Execute:
   :SimplenoteNew
-  let s:sntitle = expand('%:t')
-  let s:snstart = strridx(s:sntitle, "_")+1
-  let s:snkey = strpart(s:sntitle, s:snstart)
+  let b:sntitle = expand('%:t')
+  let b:snstart = strridx(b:sntitle, "_")+1
+  let b:snkey = strpart(b:sntitle, b:snstart)
 
 Given:
   A sixth test note
 
 Execute (Open a note by key):
   :SimplenoteNew
-  execute "SimplenoteOpen " . s:snkey
+  execute "SimplenoteOpen " . b:snkey
 
 Expect:
   A fifth test note

--- a/tests/simplenote.vader
+++ b/tests/simplenote.vader
@@ -232,12 +232,51 @@ Expect:
   A third version of a note
 
 
+
+
+# Save a note to a local file
+Given:
+  A note that will be saved to disk
+
+Execute (Save a note to a local file with :w {file}):
+  :SimplenoteNew
+  :w testNote.txt
+  :read testNote.txt 
+  :call delete("test.txt")
+
+Expect:
+  A note that will be saved to disk
+  A note that will be saved to disk
+
+
+# Save a note to a local file with :saveas
+Given:
+  A note that will be saved to disk and then modified locally
+
+Execute (Save a note to a local file with :saveas {file}):
+  :SimplenoteNew
+  :saveas testNote.txt
+  :call setline(2 ,"Local modification")
+  :w
+  :%d
+  :e!
+
+Expect:
+  A note that will be saved to disk and then modified locally
+  Local modification
+
+Execute (Delete test file):
+  :call delete("testNote.txt")
+
+
+
+
 # Get a list of notes
 Execute (Get a list of notes):
   :SimplenoteList
   "Below is required as Simplenote list sets buffer to unmodifiable so need to set it to modifiable... 
   :set modifiable
-  AssertEqual 10, line('$')
+  AssertEqual 12, line('$')
   "and clear it
   :1,$d
 


### PR DESCRIPTION
After a bit of fiddling I think I've found a way to allow these two commands to work as expected. The trick is to compare the destination file name ("amatch") with the current buffer file name. If they are different then the user is trying to save the buffer contents to a different (new) file. 

:saveas was a bit more difficult, in this case the amatch and %:p have the same value (the new file) and the only way I found to detect what was happening was to use the BufFilePre event handler. 

I hope you like it!