### PR TITLE
Remove doc refereces to old `Simplenote` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ If you want to retrieve a specific version of a note use:
     :SimplenoteVersion X
 
 where X is an integer version number. To restore that version of a note you
-would just use `:Simplenote -u`. To get back to the most recent version of a
+would just use `:SimplenoteUpdate`. To get back to the most recent version of a
 note use:
 
     :SimplenoteVersion
 
-Therefore you can also use `:Simplenote -v` when no local changes have been made
-to pull in the most recent changes from the remote note. To delete the note,
-execute
+Therefore you can also use `:SimplenoteVersion` when no local changes have been
+made to pull in the most recent changes from the remote note. To delete the
+note, execute
 
     :SimplenoteTrash
 
@@ -123,8 +123,8 @@ also exists a command to create new notes.
     :SimplenoteNew
 
 creates a new note with the contents of the current buffer. Once the note is
-created, `:Simplenote -u` updates the newly created note, also with the contents
-of the current buffer.
+created, `:SimplenoteUpdate` (or `:w`) updates the newly created note, also
+with the contents of the current buffer.
 
 Tagging notes is also supported. If you enter
 
@@ -257,7 +257,7 @@ this doc. But if you have done that, you can add a shell alias or script
 exploiting `proxychains` to ease the invoking of simplenote.vim
 
     # as for zsh
-    alias simplenote="proxychains -q vim -c 'Simplenote -l'"
+    alias simplenote="proxychains -q vim -c SimplenoteList"
 
 ## Development
 

--- a/autoload/SimplenoteUtilities.py
+++ b/autoload/SimplenoteUtilities.py
@@ -629,7 +629,7 @@ class SimplenoteVimInterface(object):
                                 buffer[:] = list(map(lambda x: unicode(x), note["content"].split("\n")))
                             # Need to set as unmodified so can continue to browse through versions
                             vim.command("setlocal nomodified")
-                            print("Displaying note ID %s version %s. To restore, :Simplenote -u, to revert to most recent, :Simplenote -v" % (note_id, version))
+                            print("Displaying note ID %s version %s. To restore, :SimplenoteUpdate, to revert to most recent, :SimplenoteVersion" % (note_id, version))
                         else:
                             print("Error fetching note data. Perhaps that version isn't available.")
                 else:

--- a/doc/simplenote.txt
+++ b/doc/simplenote.txt
@@ -66,7 +66,7 @@ Now you can take simple notes directly from your favourite editor.
     Opens the note corresponding to the given {notekey}. This is useful for
     configuring shortcuts to specific notes, e.g. >
     " add :Todo command
-    command Todo Simplenote -o <yourtodonotekey>
+    command Todo SimplenoteOpen <yourtodonotekey>
 <
 
 ==============================================================================


### PR DESCRIPTION
There hasn't been a `:Simplenote` command that accepts arguments since 1.3.0 in 2016, so remove all references to commands like

    :Simplenote -v

from the documentation and Python source code.

Closes #118.