### PR TITLE
Clear synmaxcol in scratch buffer to fix display bug

### DIFF
--- a/autoload/simplenote.vim
+++ b/autoload/simplenote.vim
@@ -173,6 +173,7 @@ function! s:ScratchBuffer()
     setlocal bufhidden=hide
     setlocal noswapfile
     setlocal cursorline
+    setlocal synmaxcol=0
 
     if (s:vbuff == 0) && (s:listsize > 0)
     "    exe "resize " . s:listsize


### PR DESCRIPTION
# Bug

My `.vimrc` contains:

```vim
set synmaxcol=256
```

When my buffer width is especially large, the Simplenote list looks garbled when I run `:SimplenoteList` (for display purposes I compressed the whitespace between the titles and timestamps, and the actual titles are redacted with "X"):

```
|d|XXXX|                                [|D|2025-06-04 11:59:54|]
|y|XXXXXXXXXXXXX|                       [|D|2025-04-03 19:54:48|]
|d|XXXXXXXXXXXXXXXXXXXXXXXXXX|          [|D|2025-06-03 21:01:25|]
|d|XXXXXXXXXXXXXXXXXXXXXXXX|            [|D|2025-06-03 21:00:43|]
|w|XXXXXXXXXXXXXXXX|                    [|D|2025-06-01 18:42:07|]
|w|XXXXXXXXX|                           [|D|2025-06-01 12:54:55|]
|w|XXXXXXXXXXXXXXXXXXXXXXX|             [|D|2025-05-28 13:13:53|]
|m|XXXX|                                [|D|2025-05-21 18:42:20|]
|m|XXXXXXXXXXXXXXXXXX|                  [|D|2025-05-16 23:55:37|]
```

# Fix

Clearing `synmaxcol` when opening a Simplenote scratch buffer fixes the bug.

# Alternatives

Users might want `synmaxcol` enabled within the Simplenote notes themselves, so it might be more precise to only clear `synmaxcol` in the index and note the notes, but I don't know how to do that.